### PR TITLE
fix path of session folder on windows

### DIFF
--- a/map-merger.go
+++ b/map-merger.go
@@ -429,7 +429,7 @@ func main() {
 				}
 			}
 		}
-		sessionsJS += "\"" + SESSION_FOLDER + "/" + files[j].Name() + "\", "
+		sessionsJS += "\"" + strings.Replace(SESSION_FOLDER, "\\", "/", -1) + "/" + files[j].Name() + "\", "
 	}
 	sessionsJS += "];"
 	ioutil.WriteFile("session.js", []byte(sessionsJS), 0777)


### PR DESCRIPTION
On Windows path like "C:\Games\hafen-client-shovel\maps/2015-09-07 00.44.52" will not work on any browser. It's small change will fix this.
